### PR TITLE
feat: Automate Makefile execution during package installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,43 +2,50 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+import ctypes
 import glob
 import os
 import subprocess
 import sys
 
 from setuptools import find_packages, setup
-from setuptools.command.build_py import build_py
+
+"""
+CUDA_VERSION=117 make cuda11x
+"""
+def build_cuda_label(major: str, minor: str) -> str:
+    postfix = ""
+    if int(major) < 7 or (int(major) == 7 and int(minor) < 5):
+        postfix = "_nomatmul"
+    cuda_version = major + minor
+    if len(cuda_version) < 3:
+        return "cuda92" + postfix
+    if cuda_version == "110":
+        return "cuda110" + postfix
+    if cuda_version.startswith("11"):
+        return "cuda11x" + postfix
+    return "cpu"
 
 
-class MakeBuild(build_py):
-    def run(self):
-        cuda_version = self._cuda_version
-        major, minor = cuda_version.split(".")
-        cuda_label = self._build_cuda_label(*cuda_version.split("."))
-        if subprocess.call(["make", cuda_label], env={**os.environ, "CUDA_VERSION": cuda_version}) != 0:
-            sys.exit(-1)
-        super().run()
+libcudart = ctypes.CDLL("libcudart.so")
 
-    def _build_cuda_label(self, major: str, minor: str) -> str:
-        postfix = ""
-        if int(major) < 7 or (int(major) == 7 and int(minor) < 5):
-            postfix = "_nomatmul"
-        cuda_version = major + minor
-        if len(cuda_version) < 3:
-            return "cuda92" + postfix
-        if cuda_version == "110":
-            return "cuda110" + postfix
-        if cuda_version.startswith("11"):
-            return "cuda11x" + postfix
-        return "cpu"
+version = ctypes.c_int()
+err = libcudart.cudaRuntimeGetVersion(ctypes.byref(version))
+print(f"cudart.cudaRuntimeGetVersion(): {err} -- {version.value}")
 
-    @property
-    def _cuda_version(self) -> str:
-        import torch
+major = version.value // 1000
+minor = (version.value % 1000) // 10
 
-        return torch.version.cuda.replace(".", "")  # 117
+major = str(major)
+minor = str(minor)
 
+cuda_label = build_cuda_label(major, minor)
+cuda_version = major + minor
+print("=========================================")
+print(f"subprocess$ CUDA_VERSION={cuda_version} make {cuda_label}")
+print("=========================================")
+if subprocess.call(["make", cuda_label], env={**os.environ, "CUDA_VERSION": cuda_version}) != 0:
+    sys.exit(-1)
 
 libs = list(glob.glob("./bitsandbytes/libbitsandbytes*.so"))
 libs = [os.path.basename(p) for p in libs]
@@ -60,9 +67,6 @@ setup(
     url="https://github.com/TimDettmers/bitsandbytes",
     packages=find_packages(),
     package_data={"": libs},
-    cmdclass={
-        "build_py": MakeBuild,
-    },
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,22 @@
 # LICENSE file in the root directory of this source tree.
 import glob
 import os
+import subprocess
+import sys
 
 from setuptools import find_packages, setup
+from setuptools.command.build_py import build_py
+
+
+class MakeBuild(build_py):
+    def run(self):
+        cuda_version = "117"
+        cuda_label = "cuda11x"
+        make = ["make", cuda_label]
+        if subprocess.call(make, env={**os.environ, "CUDA_VERSION": cuda_version}) != 0:
+            sys.exit(-1)
+        super().run()
+
 
 libs = list(glob.glob("./bitsandbytes/libbitsandbytes*.so"))
 libs = [os.path.basename(p) for p in libs]
@@ -27,6 +41,9 @@ setup(
     url="https://github.com/TimDettmers/bitsandbytes",
     packages=find_packages(),
     package_data={"": libs},
+    cmdclass={
+        "build_py": MakeBuild,
+    },
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -31,19 +31,14 @@ libcudart = ctypes.CDLL("libcudart.so")
 
 version = ctypes.c_int()
 err = libcudart.cudaRuntimeGetVersion(ctypes.byref(version))
-print(f"cudart.cudaRuntimeGetVersion(): {err} -- {version.value}")
+print(f"cudart.cudaRuntimeGetVersion(): {version.value} (Error: {err})")
 
-major = version.value // 1000
-minor = (version.value % 1000) // 10
-
-major = str(major)
-minor = str(minor)
+major = str(version.value // 1000)
+minor = str((version.value % 1000) // 10)
 
 cuda_label = build_cuda_label(major, minor)
 cuda_version = major + minor
-print("=========================================")
-print(f"subprocess$ CUDA_VERSION={cuda_version} make {cuda_label}")
-print("=========================================")
+print(f"CUDA_VERSION={cuda_version} make {cuda_label}")
 if subprocess.call(["make", cuda_label], env={**os.environ, "CUDA_VERSION": cuda_version}) != 0:
     sys.exit(-1)
 


### PR DESCRIPTION
This PR automates building `libbitsandbytes*.so`.

When an user runs `pip install [-U] .` to install this package from source, then it
1. Loads CUDA library (`libcudart.so`)
2. Reads current runtime CUDA version (`cudart.cudaRuntimeGetVersion()`)
3. Decides Makefile label to be executed
4. Runs a subprocess with command: `CUDA_VERSION=117 make cuda11x`)

before the installation process.

The logic is from `bitsandbytes` itself:
https://github.com/lablup/bitsandbytes/blob/9e7cdc9ea95e9756d9f5621a0e2c7e2538363fae/bitsandbytes/cuda_setup/main.py#L68-L83
